### PR TITLE
fix: Lazy load metrics/models to reduce footprint

### DIFF
--- a/deepeval/metrics/__init__.py
+++ b/deepeval/metrics/__init__.py
@@ -1,60 +1,5 @@
-from .base_metric import (
-    BaseMetric,
-    BaseConversationalMetric,
-    BaseMultimodalMetric,
-    BaseArenaMetric,
-)
-
-from .dag.dag import DAGMetric
-from .bias.bias import BiasMetric
-from .toxicity.toxicity import ToxicityMetric
-from .pii_leakage.pii_leakage import PIILeakageMetric
-from .non_advice.non_advice import NonAdviceMetric
-from .misuse.misuse import MisuseMetric
-from .role_violation.role_violation import RoleViolationMetric
-from .hallucination.hallucination import HallucinationMetric
-from .answer_relevancy.answer_relevancy import AnswerRelevancyMetric
-from .summarization.summarization import SummarizationMetric
-from .g_eval.g_eval import GEval
-from .arena_g_eval.arena_g_eval import ArenaGEval
-from .faithfulness.faithfulness import FaithfulnessMetric
-from .contextual_recall.contextual_recall import ContextualRecallMetric
-from .contextual_relevancy.contextual_relevancy import ContextualRelevancyMetric
-from .contextual_precision.contextual_precision import ContextualPrecisionMetric
-from .knowledge_retention.knowledge_retention import KnowledgeRetentionMetric
-from .tool_correctness.tool_correctness import ToolCorrectnessMetric
-from .json_correctness.json_correctness import JsonCorrectnessMetric
-from .prompt_alignment.prompt_alignment import PromptAlignmentMetric
-from .task_completion.task_completion import TaskCompletionMetric
-from .argument_correctness.argument_correctness import ArgumentCorrectnessMetric
-from .mcp.mcp_task_completion import MCPTaskCompletionMetric
-from .mcp.multi_turn_mcp_use_metric import MultiTurnMCPUseMetric
-from .mcp_use_metric.mcp_use_metric import MCPUseMetric
-from .turn_relevancy.turn_relevancy import (
-    TurnRelevancyMetric,
-)
-from .conversation_completeness.conversation_completeness import (
-    ConversationCompletenessMetric,
-)
-from .role_adherence.role_adherence import (
-    RoleAdherenceMetric,
-)
-from .conversational_g_eval.conversational_g_eval import ConversationalGEval
-from .multimodal_metrics import (
-    TextToImageMetric,
-    ImageEditingMetric,
-    ImageCoherenceMetric,
-    ImageHelpfulnessMetric,
-    ImageReferenceMetric,
-    MultimodalContextualRecallMetric,
-    MultimodalContextualRelevancyMetric,
-    MultimodalContextualPrecisionMetric,
-    MultimodalAnswerRelevancyMetric,
-    MultimodalFaithfulnessMetric,
-    MultimodalToolCorrectnessMetric,
-    MultimodalGEval,
-)
-
+import importlib
+from typing import TYPE_CHECKING
 
 __all__ = [
     # Base classes
@@ -112,3 +57,138 @@ __all__ = [
     "MultimodalToolCorrectnessMetric",
     "MultimodalGEval",
 ]
+
+_SYMBOL_TO_MODULE = {
+    # Base classes
+    "BaseMetric": "deepeval.metrics.base_metric",
+    "BaseConversationalMetric": "deepeval.metrics.base_metric",
+    "BaseMultimodalMetric": "deepeval.metrics.base_metric",
+    "BaseArenaMetric": "deepeval.metrics.base_metric",
+    # Core metrics
+    "GEval": "deepeval.metrics.g_eval.g_eval",
+    "ArenaGEval": "deepeval.metrics.arena_g_eval.arena_g_eval",
+    "ConversationalGEval": "deepeval.metrics.conversational_g_eval.conversational_g_eval",
+    "DAGMetric": "deepeval.metrics.dag.dag",
+    # RAG metrics
+    "AnswerRelevancyMetric": "deepeval.metrics.answer_relevancy.answer_relevancy",
+    "FaithfulnessMetric": "deepeval.metrics.faithfulness.faithfulness",
+    "ContextualRecallMetric": "deepeval.metrics.contextual_recall.contextual_recall",
+    "ContextualRelevancyMetric": "deepeval.metrics.contextual_relevancy.contextual_relevancy",
+    "ContextualPrecisionMetric": "deepeval.metrics.contextual_precision.contextual_precision",
+    # MCP metrics
+    "MCPTaskCompletionMetric": "deepeval.metrics.mcp.mcp_task_completion",
+    "MultiTurnMCPUseMetric": "deepeval.metrics.mcp.multi_turn_mcp_use_metric",
+    "MCPUseMetric": "deepeval.metrics.mcp_use_metric.mcp_use_metric",
+    # Content quality metrics
+    "HallucinationMetric": "deepeval.metrics.hallucination.hallucination",
+    "BiasMetric": "deepeval.metrics.bias.bias",
+    "ToxicityMetric": "deepeval.metrics.toxicity.toxicity",
+    "SummarizationMetric": "deepeval.metrics.summarization.summarization",
+    # Safety and compliance metrics
+    "PIILeakageMetric": "deepeval.metrics.pii_leakage.pii_leakage",
+    "NonAdviceMetric": "deepeval.metrics.non_advice.non_advice",
+    "MisuseMetric": "deepeval.metrics.misuse.misuse",
+    "RoleViolationMetric": "deepeval.metrics.role_violation.role_violation",
+    "RoleAdherenceMetric": "deepeval.metrics.role_adherence.role_adherence",
+    # Task-specific metrics
+    "ToolCorrectnessMetric": "deepeval.metrics.tool_correctness.tool_correctness",
+    "JsonCorrectnessMetric": "deepeval.metrics.json_correctness.json_correctness",
+    "PromptAlignmentMetric": "deepeval.metrics.prompt_alignment.prompt_alignment",
+    "TaskCompletionMetric": "deepeval.metrics.task_completion.task_completion",
+    "ArgumentCorrectnessMetric": "deepeval.metrics.argument_correctness.argument_correctness",
+    "KnowledgeRetentionMetric": "deepeval.metrics.knowledge_retention.knowledge_retention",
+    # Conversational metrics
+    "TurnRelevancyMetric": "deepeval.metrics.turn_relevancy.turn_relevancy",
+    "ConversationCompletenessMetric": "deepeval.metrics.conversation_completeness.conversation_completeness",
+    # Multimodal metrics
+    "TextToImageMetric": "deepeval.metrics.multimodal_metrics.text_to_image.text_to_image",
+    "ImageEditingMetric": "deepeval.metrics.multimodal_metrics.image_editing.image_editing",
+    "ImageCoherenceMetric": "deepeval.metrics.multimodal_metrics.image_coherence.image_coherence",
+    "ImageHelpfulnessMetric": "deepeval.metrics.multimodal_metrics.image_helpfulness.image_helpfulness",
+    "ImageReferenceMetric": "deepeval.metrics.multimodal_metrics.image_reference.image_reference",
+    "MultimodalContextualRecallMetric": "deepeval.metrics.multimodal_metrics.multimodal_contextual_recall.multimodal_contextual_recall",
+    "MultimodalContextualRelevancyMetric": "deepeval.metrics.multimodal_metrics.multimodal_contextual_relevancy.multimodal_contextual_relevancy",
+    "MultimodalContextualPrecisionMetric": "deepeval.metrics.multimodal_metrics.multimodal_contextual_precision.multimodal_contextual_precision",
+    "MultimodalAnswerRelevancyMetric": "deepeval.metrics.multimodal_metrics.multimodal_answer_relevancy.multimodal_answer_relevancy",
+    "MultimodalFaithfulnessMetric": "deepeval.metrics.multimodal_metrics.multimodal_faithfulness.multimodal_faithfulness",
+    "MultimodalToolCorrectnessMetric": "deepeval.metrics.multimodal_metrics.multimodal_tool_correctness.multimodal_tool_correctness",
+    "MultimodalGEval": "deepeval.metrics.multimodal_metrics.multimodal_g_eval.multimodal_g_eval",
+}
+
+
+def __getattr__(name: str):
+    module_path = _SYMBOL_TO_MODULE.get(name)
+    if module_path is None:
+        raise AttributeError(name)
+    module = importlib.import_module(module_path)
+    obj = getattr(module, name)
+    globals()[name] = obj
+    return obj
+
+
+if TYPE_CHECKING:
+    from .answer_relevancy.answer_relevancy import AnswerRelevancyMetric
+    from .arena_g_eval.arena_g_eval import ArenaGEval
+    from .argument_correctness.argument_correctness import ArgumentCorrectnessMetric
+    from .base_metric import (
+        BaseArenaMetric,
+        BaseConversationalMetric,
+        BaseMetric,
+        BaseMultimodalMetric,
+    )
+    from .bias.bias import BiasMetric
+    from .contextual_precision.contextual_precision import ContextualPrecisionMetric
+    from .contextual_recall.contextual_recall import ContextualRecallMetric
+    from .contextual_relevancy.contextual_relevancy import ContextualRelevancyMetric
+    from .conversation_completeness.conversation_completeness import (
+        ConversationCompletenessMetric,
+    )
+    from .conversational_g_eval.conversational_g_eval import ConversationalGEval
+    from .dag.dag import DAGMetric
+    from .faithfulness.faithfulness import FaithfulnessMetric
+    from .g_eval.g_eval import GEval
+    from .hallucination.hallucination import HallucinationMetric
+    from .json_correctness.json_correctness import JsonCorrectnessMetric
+    from .knowledge_retention.knowledge_retention import KnowledgeRetentionMetric
+    from .mcp.mcp_task_completion import MCPTaskCompletionMetric
+    from .mcp.multi_turn_mcp_use_metric import MultiTurnMCPUseMetric
+    from .mcp_use_metric.mcp_use_metric import MCPUseMetric
+    from .misuse.misuse import MisuseMetric
+    from .multimodal_metrics.image_coherence.image_coherence import ImageCoherenceMetric
+    from .multimodal_metrics.image_editing.image_editing import ImageEditingMetric
+    from .multimodal_metrics.image_helpfulness.image_helpfulness import (
+        ImageHelpfulnessMetric,
+    )
+    from .multimodal_metrics.image_reference.image_reference import ImageReferenceMetric
+    from .multimodal_metrics.multimodal_answer_relevancy.multimodal_answer_relevancy import (
+        MultimodalAnswerRelevancyMetric,
+    )
+    from .multimodal_metrics.multimodal_contextual_precision.multimodal_contextual_precision import (
+        MultimodalContextualPrecisionMetric,
+    )
+    from .multimodal_metrics.multimodal_contextual_recall.multimodal_contextual_recall import (
+        MultimodalContextualRecallMetric,
+    )
+    from .multimodal_metrics.multimodal_contextual_relevancy.multimodal_contextual_relevancy import (
+        MultimodalContextualRelevancyMetric,
+    )
+    from .multimodal_metrics.multimodal_faithfulness.multimodal_faithfulness import (
+        MultimodalFaithfulnessMetric,
+    )
+    from .multimodal_metrics.multimodal_g_eval.multimodal_g_eval import MultimodalGEval
+    from .multimodal_metrics.multimodal_tool_correctness.multimodal_tool_correctness import (
+        MultimodalToolCorrectnessMetric,
+    )
+
+    # Multimodal metrics
+    from .multimodal_metrics.text_to_image.text_to_image import TextToImageMetric
+    from .non_advice.non_advice import NonAdviceMetric
+    from .pii_leakage.pii_leakage import PIILeakageMetric
+    from .prompt_alignment.prompt_alignment import PromptAlignmentMetric
+    from .role_adherence.role_adherence import RoleAdherenceMetric
+    from .role_violation.role_violation import RoleViolationMetric
+    from .summarization.summarization import SummarizationMetric
+    from .task_completion.task_completion import TaskCompletionMetric
+    from .tool_correctness.tool_correctness import ToolCorrectnessMetric
+    from .toxicity.toxicity import ToxicityMetric
+    from .turn_relevancy.turn_relevancy import TurnRelevancyMetric

--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -1,14 +1,14 @@
 from abc import abstractmethod
-from typing import Optional, Dict, List
+from typing import Dict, List, Optional
 
+from deepeval.models.base_model import DeepEvalBaseLLM
 from deepeval.test_case import (
-    LLMTestCase,
-    ConversationalTestCase,
-    MLLMTestCase,
-    LLMTestCaseParams,
     ArenaTestCase,
+    ConversationalTestCase,
+    LLMTestCase,
+    LLMTestCaseParams,
+    MLLMTestCase,
 )
-from deepeval.models import DeepEvalBaseLLM
 
 
 class BaseMetric:

--- a/deepeval/models/__init__.py
+++ b/deepeval/models/__init__.py
@@ -1,33 +1,5 @@
-from deepeval.models.base_model import (
-    DeepEvalBaseModel,
-    DeepEvalBaseLLM,
-    DeepEvalBaseMLLM,
-    DeepEvalBaseEmbeddingModel,
-)
-from deepeval.models.llms import (
-    GPTModel,
-    AzureOpenAIModel,
-    LocalModel,
-    OllamaModel,
-    AnthropicModel,
-    GeminiModel,
-    AmazonBedrockModel,
-    LiteLLMModel,
-    KimiModel,
-    GrokModel,
-    DeepSeekModel,
-)
-from deepeval.models.mlllms import (
-    MultimodalOpenAIModel,
-    MultimodalOllamaModel,
-    MultimodalGeminiModel,
-)
-from deepeval.models.embedding_models import (
-    OpenAIEmbeddingModel,
-    AzureOpenAIEmbeddingModel,
-    LocalEmbeddingModel,
-    OllamaEmbeddingModel,
-)
+import importlib
+from typing import TYPE_CHECKING
 
 __all__ = [
     "DeepEvalBaseModel",
@@ -53,3 +25,75 @@ __all__ = [
     "LocalEmbeddingModel",
     "OllamaEmbeddingModel",
 ]
+
+_SYMBOL_TO_MODULE = {
+    # Base types
+    "DeepEvalBaseModel": "deepeval.models.base_model",
+    "DeepEvalBaseLLM": "deepeval.models.base_model",
+    "DeepEvalBaseMLLM": "deepeval.models.base_model",
+    "DeepEvalBaseEmbeddingModel": "deepeval.models.base_model",
+    # LLMs
+    "GPTModel": "deepeval.models.llms.openai_model",
+    "AzureOpenAIModel": "deepeval.models.llms.azure_model",
+    "LocalModel": "deepeval.models.llms.local_model",
+    "OllamaModel": "deepeval.models.llms.ollama_model",
+    "AnthropicModel": "deepeval.models.llms.anthropic_model",
+    "GeminiModel": "deepeval.models.llms.gemini_model",
+    "AmazonBedrockModel": "deepeval.models.llms.amazon_bedrock_model",
+    "LiteLLMModel": "deepeval.models.llms.litellm_model",
+    "KimiModel": "deepeval.models.llms.kimi_model",
+    "GrokModel": "deepeval.models.llms.grok_model",
+    "DeepSeekModel": "deepeval.models.llms.deepseek_model",
+    # Multimodal LLMs
+    "MultimodalOpenAIModel": "deepeval.models.mlllms.openai_model",
+    "MultimodalOllamaModel": "deepeval.models.mlllms.ollama_model",
+    "MultimodalGeminiModel": "deepeval.models.mlllms.gemini_model",
+    # Embedding models
+    "OpenAIEmbeddingModel": "deepeval.models.embedding_models.openai_embedding_model",
+    "AzureOpenAIEmbeddingModel": "deepeval.models.embedding_models.azure_embedding_model",
+    "LocalEmbeddingModel": "deepeval.models.embedding_models.local_embedding_model",
+    "OllamaEmbeddingModel": "deepeval.models.embedding_models.ollama_embedding_model",
+}
+
+
+def __getattr__(name: str):
+    module_path = _SYMBOL_TO_MODULE.get(name)
+    if module_path is None:
+        raise AttributeError(name)
+    module = importlib.import_module(module_path)
+    obj = getattr(module, name)
+    globals()[name] = obj  # cache for subsequent access
+    return obj
+
+
+if TYPE_CHECKING:
+    from deepeval.models.base_model import (
+        DeepEvalBaseEmbeddingModel,
+        DeepEvalBaseLLM,
+        DeepEvalBaseMLLM,
+        DeepEvalBaseModel,
+    )
+    from deepeval.models.embedding_models import (
+        AzureOpenAIEmbeddingModel,
+        LocalEmbeddingModel,
+        OllamaEmbeddingModel,
+        OpenAIEmbeddingModel,
+    )
+    from deepeval.models.llms import (
+        AmazonBedrockModel,
+        AnthropicModel,
+        AzureOpenAIModel,
+        DeepSeekModel,
+        GeminiModel,
+        GPTModel,
+        GrokModel,
+        KimiModel,
+        LiteLLMModel,
+        LocalModel,
+        OllamaModel,
+    )
+    from deepeval.models.mlllms import (
+        MultimodalGeminiModel,
+        MultimodalOllamaModel,
+        MultimodalOpenAIModel,
+    )

--- a/tests/test_core/test_lazy_imports.py
+++ b/tests/test_core/test_lazy_imports.py
@@ -1,0 +1,70 @@
+import subprocess
+import sys
+import textwrap
+
+
+def run_py(code: str):
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert (
+        proc.returncode == 0
+    ), f"Subprocess failed (rc={proc.returncode}):\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+
+
+def test_metrics_lazy_import_subprocess():
+    code = textwrap.dedent(
+        """
+        import sys
+        import deepeval.metrics as mm
+        print("bias_loaded", "deepeval.metrics.bias.bias" in sys.modules)
+        from deepeval.metrics import GEval
+        print("g_eval_loaded", "deepeval.metrics.g_eval.g_eval" in sys.modules)
+        print("base_metric_loaded", "deepeval.metrics.base_metric" in sys.modules)
+        print("models_base_loaded", "deepeval.models.base_model" in sys.modules)
+        # Note: deepeval.metrics.utils imports from deepeval.models, which may load llms
+        print("models_llms_loaded", any(k.startswith("deepeval.models.llms") for k in sys.modules))
+        print("bias_loaded_after", "deepeval.metrics.bias.bias" in sys.modules)
+        """
+    )
+    out = run_py(code)
+    assert "bias_loaded False" in out
+    assert "g_eval_loaded True" in out
+    assert "base_metric_loaded True" in out
+    assert "models_base_loaded True" in out
+    # Accept either behavior depending on utils import path; we only assert bias remains lazy
+    assert "bias_loaded_after False" in out
+
+
+def test_public_api_models_subset():
+    # Ensure a few representative symbols are importable
+    from deepeval.models import (
+        DeepEvalBaseLLM,
+        GPTModel,
+        MultimodalGeminiModel,
+        OpenAIEmbeddingModel,
+    )
+
+    assert isinstance(GPTModel, type)
+    assert isinstance(DeepEvalBaseLLM, type)
+    assert isinstance(MultimodalGeminiModel, type)
+    assert isinstance(OpenAIEmbeddingModel, type)
+
+
+def test_public_api_metrics_subset():
+    # Ensure a few representative symbols are importable
+    from deepeval.metrics import (
+        AnswerRelevancyMetric,
+        BaseMetric,
+        GEval,
+        MultimodalGEval,
+    )
+
+    assert isinstance(GEval, type)
+    assert isinstance(BaseMetric, type)
+    assert isinstance(AnswerRelevancyMetric, type)
+    assert isinstance(MultimodalGEval, type)
+


### PR DESCRIPTION
Switch deepeval.metrics and deepeval.models from eager to lazy imports via module-level getattr, so only the symbols actually used are imported.

Public API is preserved; import time, memory footprint, and side effects are reduced. Adds focused import tests (test_core/test_lazy_imports.py) to validate behavior.